### PR TITLE
Add more return values from the api request

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -76,9 +76,17 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'    => Arr::get($user, 'data.cid'),
-            'name'  => Arr::get($user, 'data.personal.name_full'),
-            'email' => Arr::get($user, 'data.personal.email'),
+            'cid'    => Arr::get($user, 'data.cid'),
+            'first_name' => Arr::get($user, 'data.personal.name_first'),
+            'last_name' => Arr::get($user, 'data.personal.name_last'),
+            'full_name'  => Arr::get($user, 'data.personal.name_full'),
+            'rating' => Arr::get($user, 'data.vatsim.rating.id'),
+            'pilot_rating' => Arr::get($user, 'data.vatsim.pilotrating.id'),
+            'region' => Arr::get($user, 'data.vatsim.region.id'),
+            'division' => Arr::get($user, 'data.vatsim.division.id'),
+            'subdivision' => Arr::get($user, 'data.vatsim.subdivision.id'),
+
+
         ]);
     }
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ return Socialite::driver('vatsim')->requiredScopes(['email'])->redirect();
 
 ### Returned User fields
 
-- ``id``
-- ``name``
+- ``cid``
+- ``first_name``
+- ``last_name``
+- ``full_name``
 - ``email``
+- ``rating``
+- ``pilotrating``
+- ``region``
+- ``division``
+- ``subdivision``
+


### PR DESCRIPTION
When using the VATSIM OAuth, the return values you have set now work, but in most applications, the developers of these sites are looking into more of the data that the OAuth API returns.

I have added all the most common items that are normally used by VATSIM OAuth users.

See VATSIM Documentation here: https://vatsim.dev/api/connect-api/get-user

If you have any questions please let me know!